### PR TITLE
Ignore timestamps coming from the device, use current time.

### DIFF
--- a/custom_components/qingping_cgdn1/sensor.py
+++ b/custom_components/qingping_cgdn1/sensor.py
@@ -116,7 +116,8 @@ async def async_setup_entry(
 
             timestamp = payload.get("timestamp")
             if timestamp is not None:
-                status_sensor.update_timestamp(timestamp)
+                # Some devices have bad timestamps, so just use current time
+                status_sensor.update_timestamp(str(int(time.time())))
 
             mac_address = payload.get("mac")
             if mac_address is not None:


### PR DESCRIPTION
Hi there,

I found out that some of my devices seem to have a unix time starting at 0 after factory reset, which messes up the computation to check if they are offline or not. So when we process an incoming message, just use server side time.

e.g. I would see the following MQTT messages:

```
2024-12-14 17:22:29.631 DEBUG (MainThread) [custom_components.qingping_cgdn1.sensor] qingping mac 7CC2940870C5
2024-12-14 17:22:29.631 DEBUG (MainThread) [custom_components.qingping_cgdn1.sensor] sensor data [{'timestamp': {'value': 318071}, 'battery': {'value': 100, 'status': 2}, 'temperature': {'value': 19.3, 'status': 0, 'unit': 'F', 'co2_calib_state': 0}, 'humidity': {'value': 68.54, 'status': 0, 'unit': '%'}, 'co2': {'value': 620, 'status': 0}, 'pm25': {'value': 1, 'status': 0}, 'pm10': {'value': 1, 'status': 0}}]
2024-12-14 17:22:33.622 DEBUG (MainThread) [custom_components.qingping_cgdn1.sensor] qingping mac CCB5D126C35C
2024-12-14 17:22:33.623 DEBUG (MainThread) [custom_components.qingping_cgdn1.sensor] sensor data [{'timestamp': {'value': 609534}, 'battery': {'value': 97, 'status': 2}, 'temperature': {'value': 23.35, 'status': 0, 'unit': 'C', 'co2_calib_state': 0}, 'humidity': {'value': 57.49, 'status': 0, 'unit': '%'}, 'co2': {'value': 610, 'status': 0}, 'pm25': {'value': 0, 'status': 0}, 'pm10': {'value': 0, 'status': 0}}]
2024-12-14 17:22:34.159 DEBUG (MainThread) [custom_components.qingping_cgdn1.sensor] qingping mac 7CC294C99964
2024-12-14 17:22:34.159 DEBUG (MainThread) [custom_components.qingping_cgdn1.sensor] sensor data [{'timestamp': {'value': 1734225753}, 'battery': {'value': 100, 'status': 2}, 'temperature': {'value': 21.43, 'status': 0, 'unit': 'F', 'co2_calib_state': 0}, 'humidity': {'value': 55.83, 'status': 0, 'unit': '%'}, 'co2': {'value': 596, 'status': 0}, 'pm25': {'value': 1, 'status': 0}, 'pm10': {'value': 1, 'status': 0}}]
2024-12-14 17:22:34.439 DEBUG (MainThread) [custom_components.qingping_cgdn1.sensor] qingping mac 7CC294C99382
2024-12-14 17:22:34.439 DEBUG (MainThread) [custom_components.qingping_cgdn1.sensor] sensor data [{'timestamp': {'value': 1734225751}, 'battery': {'value': 100, 'status': 2}, 'temperature': {'value': 20.52, 'status': 0, 'unit': 'F', 'co2_calib_state': 0}, 'humidity': {'value': 60.21, 'status': 0, 'unit': '%'}, 'co2': {'value': 681, 'status': 0}, 'pm25': {'value': 0, 'status': 0}, 'pm10': {'value': 0, 'status': 0}}]
2024-12-14 17:22:34.958 DEBUG (MainThread) [custom_components.qingping_cgdn1.sensor] qingping mac 7CC294086D26
2024-12-14 17:22:34.958 DEBUG (MainThread) [custom_components.qingping_cgdn1.sensor] sensor data [{'timestamp': {'value': 1734225743}, 'battery': {'value': 100, 'status': 2}, 'temperature': {'value': 20.12, 'status': 0, 'unit': 'F', 'co2_calib_state': 0}, 'humidity': {'value': 67.22, 'status': 0, 'unit': '%'}, 'co2': {'value': 558, 'status': 0}, 'pm25': {'value': 0, 'status': 0}, 'pm10': {'value': 0, 'status': 0}}]
```

You can see the first 2 timestamps look completely out of whack. I haven't seen any way to reset the clock on those devices, maybe there is an MQTT command that could do that ?